### PR TITLE
Split development and production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.15.3",
-    "nosql": "^5.0.3",
     "rpi-gpio": "^0.8.1",
-    "socket.io": "^2.0.3",
     "node-dht-sensor": "0.0.32"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "express": "^4.15.3",
+    "nosql": "^5.0.3",
     "rpi-gpio": "^0.8.1",
+    "socket.io": "^2.0.3",
     "node-dht-sensor": "0.0.32"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,12 @@
     "express": "^4.15.3",
     "nosql": "^5.0.3",
     "rpi-gpio": "^0.8.1",
+    "socket.io": "^2.0.3",
+    "node-dht-sensor": "0.0.32"
+  },
+  "devDependencies": {
+    "express": "^4.15.3",
+    "nosql": "^5.0.3",
     "socket.io": "^2.0.3"
   }
 }


### PR DESCRIPTION
package.json offers separate list of development dependencies. 
When we clone the project we can install them by running `npm install --only=dev`.

By default, `npm install` installs both `dependencies` and `devDependencies`.